### PR TITLE
Shadow info for parts in updates: 22-03 (complete) and 22-02 (in progress)

### DIFF
--- a/p/axl5hol8.dat
+++ b/p/axl5hol8.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Technic Axle Hole Rounded Perimeter"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=axleHole2] [gender=F] [caps=none] [secs=A 6 1] [slide=true] [pos=0 1 0] [scale=YOnly]

--- a/parts/10177.dat
+++ b/parts/10177.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Minifig Leg Right Robotic"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 4] [pos=-10 28 0]

--- a/parts/14395.dat
+++ b/parts/14395.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Arch  1 x  5 x  4 with Thin Walls"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 20] [pos=0 96 0]

--- a/parts/15515.dat
+++ b/parts/15515.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Duplo Plant Flower  4 x  4 x  1 with  5 Round Petals and  4 Top Studs"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 12 44] [pos=0 48 0] [grid=C 2 C 2 40 40]

--- a/parts/22921.dat
+++ b/parts/22921.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Minifig Tool Hose Nozzle with Handle at Bottom and Top"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 4 16] [slide=true] [pos=0 -8 0] [ori=1 0 0 0 -1 0 0 0 -1]
+0 !LDCAD SNAP_CYL [ID=studC] [gender=M] [caps=one] [secs=R 6 4] [pos=0 -14 -26] [ori=1 0 0 0 0 -1 0 1 0]
+0 !LDCAD SNAP_CYL [gender=M] [caps=none] [secs=R 4 20] [center=true] [pos=0 -30 0] [ori=0 -1 0 1 0 0 0 0 1]

--- a/parts/23325.dat
+++ b/parts/23325.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Electric Motor Unit  6 x 18 x  4 - Battery Compartment Lid"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [grid=C 8 C 4 20 20]

--- a/parts/243.dat
+++ b/parts/243.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Train Wheel Spoked with Cylindrical Rim with 8 LDU Axle Hole"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 4 18] [slide=true] [pos=0 0 -8] [ori=1 0 0 0 0 1 0 -1 0]

--- a/parts/24782.dat
+++ b/parts/24782.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "Minifig Skirt Wavy"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 11] [pos=10 0 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 11] [pos=-10 0 0]

--- a/parts/2536b.dat
+++ b/parts/2536b.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Plant Tree Palm Trunk with Short Indented Connector"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_GEN [gender=F] [bounding=sph 10] [placement=free] [pos=0 -32 0]
+0 !LDCAD SNAP_GEN [gender=M] [bounding=sph 10] [placement=free] [pos=0 3 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 6 16   R 4 8] [pos=0 8 0]

--- a/parts/29304.dat
+++ b/parts/29304.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Duplo Plate  4 x  8 Round Semicircle"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 12 20] [pos=0 24 -40] [grid=C 8 C 2 40 40]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 12 20] [pos=0 24 -100] [grid=C 6 1 40 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 12 20] [pos=0 24 -140] [grid=C 4 1 40 0]

--- a/parts/30150.dat
+++ b/parts/30150.dat
@@ -2,6 +2,10 @@
 0 Author: Roland Melkert [roland]
 0 !LICENSE Free for non-commercial use.
 
+0 !HISTORY 2022-07-10 [MilanV] antistud and bar snap info added
+
 0 //TODO: Needs new orientation restriction
 0 !LDCAD SNAP_GEN [gender=M] [bounding=box 30 8 40] [pos=0 -32 0]
 0 !LDCAD SNAP_GEN [gender=F] [bounding=box 30 8 40] [pos=0 8 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 0] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 4 C 3 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 4 4] [pos=0 4 -10] [grid=1 2 0 20]

--- a/parts/30517.dat
+++ b/parts/30517.dat
@@ -1,8 +1,13 @@
 0 LDCad info for "Support  2 x  2 x 10 Girder Triangular"
 0 Author: Roland Melkert [roland]
 0 !LICENSE Free for non-commercial use.
+0 !HISTORY 2022-07-08 [MilanV] Fixed during update 22-03
 
 0 !LDCAD SNAP_CLEAR [ID=axleHole2]
 0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 20] [pos=0 240 0] [grid=C 2 C 2 20 20]
 0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 6 4] [grid=C 2 C 2 20 20]
 0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4   A 6 16] [pos=0 240 0]
+0 !LDCAD SNAP_CYL [ID=studO] [gender=F] [caps=one] [secs=R 4 4] [pos=-10 -4 10] [ori=1 0 0 0 -1 0 0 0 -1]
+0 !LDCAD SNAP_CYL [ID=studO] [gender=F] [caps=one] [secs=R 4 4] [pos=-10 -4 -10] [ori=1 0 0 0 -1 0 0 0 -1]
+0 !LDCAD SNAP_CYL [ID=studO] [gender=F] [caps=one] [secs=R 4 4] [pos=10 -4 -10] [ori=1 0 0 0 -1 0 0 0 -1]
+0 !LDCAD SNAP_CYL [ID=studO] [gender=F] [caps=one] [secs=R 4 4] [pos=10 -4 10] [ori=1 0 0 0 -1 0 0 0 -1]

--- a/parts/30520.dat
+++ b/parts/30520.dat
@@ -1,6 +1,7 @@
 0 LDCad info for "Brick  2 x  8 with Axleholes and  6 Notches"
 0 Author: Roland Melkert [roland]
 0 !LICENSE Free for non-commercial use.
+0 !HISTORY 2022-07-08 [MilanV] Fixed during update 22-03
 
 0 //Base brick
 0 !LDCAD SNAP_INCL [ref=3007.dat]
@@ -9,3 +10,4 @@
 0 // Drop the half baked ones.
 0 !LDCAD SNAP_CLEAR [id=axleHole]
 0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 6 4   A 6 20] [pos=0 24 0] [grid=C 2 1 120 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 20] [pos=0 24 0] [grid=C 8 C 2 20 20]

--- a/parts/30924.dat
+++ b/parts/30924.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Minifig Arm Bandage Wrapped"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 4 8] [slide=true] [pos=0 -8 0] [ori=1 0 0 0 -1 0 0 0 -1]

--- a/parts/3430.dat
+++ b/parts/3430.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Forklift Rails  2 x  4 x  5.667"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 0] [grid=C 2 C 2 20 20]

--- a/parts/35709.dat
+++ b/parts/35709.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Minifig Costume Flowerpot"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 11] [pos=10 0 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-10 -3 0] [ori=1 0 0 0 -1 0 0 0 -1] [grid=2 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 11] [pos=-10 0 0]

--- a/parts/40373.dat
+++ b/parts/40373.dat
@@ -1,0 +1,9 @@
+0 LDCad info for "Animal Dinosaur Body Quarter with peg holes {unofficial}"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=F] [caps=one] [secs=R 8 2   R 6 2] [pos=40 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_INCL [ref=connhole.dat] [pos=10 9.5 9.5] [ori=0 -1 0 1 0 0 0 0 1] [grid=2 1 48 0]
+0 !LDCAD SNAP_INCL [ref=connhole.dat] [pos=20 33.5 9.5] [ori=0 0 -1 1 0 0 0 -1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=10 73.5 19.5] [grid=1 C 2 0 20]
+0 !LDCAD SNAP_CYL [ID=dinoNeck] [gender=M] [caps=one] [secs=R 10 40] [pos=20 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]

--- a/parts/40373.dat
+++ b/parts/40373.dat
@@ -2,8 +2,8 @@
 0 Author: Milan Vančura [MilanV]
 0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
 
-0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=F] [caps=one] [secs=R 8 2   R 6 2] [pos=40 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [group=dinoLeg] [gender=F] [caps=one] [secs=R 8 2   R 6 2] [pos=40 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]
 0 !LDCAD SNAP_INCL [ref=connhole.dat] [pos=10 9.5 9.5] [ori=0 -1 0 1 0 0 0 0 1] [grid=2 1 48 0]
 0 !LDCAD SNAP_INCL [ref=connhole.dat] [pos=20 33.5 9.5] [ori=0 0 -1 1 0 0 0 -1 0]
 0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=10 73.5 19.5] [grid=1 C 2 0 20]
-0 !LDCAD SNAP_CYL [ID=dinoNeck] [gender=M] [caps=one] [secs=R 10 40] [pos=20 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [group=dinoNeck] [gender=M] [caps=one] [secs=R 10 40] [pos=20 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]

--- a/parts/40374.dat
+++ b/parts/40374.dat
@@ -1,0 +1,9 @@
+0 LDCad info for "Animal Dinosaur Body Quarter with Pins"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 8 2   R 6 16   _L 6.25 2] [pos=0 9.5 9.5] [ori=0 -1 0 1 0 0 0 0 1] [grid=2 1 48 0]
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 8 2   R 6 16   _L 6.25 2] [pos=-20 33.5 -0.5] [ori=0 0 1 1 0 0 0 1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-10 72 20] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 2 1 20 0]
+0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=F] [caps=one] [secs=R 8 2   R 6 2] [pos=-40 33.5 60] [ori=0 -1 0 1 0 0 0 0 1]
+0 !LDCAD SNAP_CYL [ID=dinoNeck] [gender=M] [caps=one] [secs=R 10 40] [pos=20 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]

--- a/parts/40374.dat
+++ b/parts/40374.dat
@@ -5,5 +5,5 @@
 0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 8 2   R 6 16   _L 6.25 2] [pos=0 9.5 9.5] [ori=0 -1 0 1 0 0 0 0 1] [grid=2 1 48 0]
 0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 8 2   R 6 16   _L 6.25 2] [pos=-20 33.5 -0.5] [ori=0 0 1 1 0 0 0 1 0]
 0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-10 72 20] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 2 1 20 0]
-0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=F] [caps=one] [secs=R 8 2   R 6 2] [pos=-40 33.5 60] [ori=0 -1 0 1 0 0 0 0 1]
-0 !LDCAD SNAP_CYL [ID=dinoNeck] [gender=M] [caps=one] [secs=R 10 40] [pos=20 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [group=dinoLeg] [gender=F] [caps=one] [secs=R 8 2   R 6 2] [pos=-40 33.5 60] [ori=0 -1 0 1 0 0 0 0 1]
+0 !LDCAD SNAP_CYL [group=dinoNeck] [gender=M] [caps=one] [secs=R 10 40] [pos=20 33.5 60] [ori=0 1 0 1 0 0 0 0 -1]

--- a/parts/40375.dat
+++ b/parts/40375.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "Animal Dinosaur Body Neck/Tail Ring"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [ID=dinoNeck] [gender=F] [caps=none] [secs=R 10 40] [pos=20 0 0] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=0 0 -33] [ori=1 0 0 0 0 1 0 -1 0]

--- a/parts/40375.dat
+++ b/parts/40375.dat
@@ -2,5 +2,5 @@
 0 Author: Milan Vančura [MilanV]
 0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
 
-0 !LDCAD SNAP_CYL [ID=dinoNeck] [gender=F] [caps=none] [secs=R 10 40] [pos=20 0 0] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [group=dinoNeck] [gender=F] [caps=none] [secs=R 10 40] [pos=20 0 0] [ori=0 1 0 1 0 0 0 0 -1]
 0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=0 0 -33] [ori=1 0 0 0 0 1 0 -1 0]

--- a/parts/40386.dat
+++ b/parts/40386.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Animal Dinosaur Flipper with Pin"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 8 2   R 6 16   _L 6.25 2] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/40395.dat
+++ b/parts/40395.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Animal Dinosaur Tail/Neck Curved with Black Pin"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=52.92893219 0 131.92893219] [ori=0.70710678 0.70710678 0 0 0 -1 -0.70710678 0.70710678 0]

--- a/parts/40396.dat
+++ b/parts/40396.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Animal Dinosaur Tail/Neck S Curve with Black Pin"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 7] [pos=48 0 59.5] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/40397.dat
+++ b/parts/40397.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "Animal Dinosaur Legs Short (Complete)"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=M] [caps=one] [secs=R 8 2   R 6 2] [pos=-40 0 0] [ori=0 -1 0 1 0 0 0 0 1]
+0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=M] [caps=one] [secs=R 8 2   R 6 2] [pos=40 0 0] [ori=0 1 0 1 0 0 0 0 -1]

--- a/parts/40397.dat
+++ b/parts/40397.dat
@@ -2,5 +2,5 @@
 0 Author: Milan Vančura [MilanV]
 0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
 
-0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=M] [caps=one] [secs=R 8 2   R 6 2] [pos=-40 0 0] [ori=0 -1 0 1 0 0 0 0 1]
-0 !LDCAD SNAP_CYL [ID=dinoLeg] [gender=M] [caps=one] [secs=R 8 2   R 6 2] [pos=40 0 0] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [group=dinoLeg] [gender=M] [caps=one] [secs=R 8 2   R 6 2] [pos=-40 0 0] [ori=0 -1 0 1 0 0 0 0 1]
+0 !LDCAD SNAP_CYL [group=dinoLeg] [gender=M] [caps=one] [secs=R 8 2   R 6 2] [pos=40 0 0] [ori=0 1 0 1 0 0 0 0 -1]

--- a/parts/41668.dat
+++ b/parts/41668.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Constraction Foot  2 x  5 x  3 with Ball Socket"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_GEN [group=techBallJnt] [gender=F] [bounding=sph 12.7] [match=size] [placement=free]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 6 4] [slide=true] [pos=-2 0 0] [ori=0 -1 0 1 0 0 0 0 1] [grid=1 C 2 1 0 28 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [slide=true] [pos=0 40 20] [ori=0 1 0 -1 0 0 0 0 1] [grid=1 2 1 0 20 0]

--- a/parts/41969.dat
+++ b/parts/41969.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Duplo Support Column  2 x  3 x  3 with  2 Top Studs"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 12 20] [pos=0 144 0] [grid=C 3 C 2 40 40]

--- a/parts/4237.dat
+++ b/parts/4237.dat
@@ -1,7 +1,9 @@
 0 LDCad info for "Container  4 x  6 x  2.333 Crate"
 0 Author: Roland Melkert [roland]
 0 !LICENSE Free for non-commercial use.
+0 !HISTORY 2022-07-08 [MilanV] Fixed during update 22-03
 
 0 //TODO: Needs new orientation restriction
 0 !LDCAD SNAP_GEN [gender=M] [bounding=box 40 8 60] [pos=0 -48 0]
 0 !LDCAD SNAP_GEN [gender=F] [bounding=box 40 8 60] [pos=0 8 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 0] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 6 C 4 20 20]

--- a/parts/44511.dat
+++ b/parts/44511.dat
@@ -1,0 +1,11 @@
+0 LDCad info for "Roof Piece  8 x 12 x 10 Half Onion Dome"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [ID=studC] [gender=M] [caps=one] [secs=R 6 4] [pos=-10 0 -10]
+0 !LDCAD SNAP_CYL [ID=studC] [gender=M] [caps=one] [secs=R 6 4] [pos=10 0 -10]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 240 -90] [grid=C 4 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=70 240 -20] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 4 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-70 240 -20] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 4 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-40 240 -70] [grid=C 2 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=40 240 -70] [grid=C 2 1 20 0]

--- a/parts/47991.dat
+++ b/parts/47991.dat
@@ -1,0 +1,9 @@
+0 LDCad info for "Panel  5 x 10 x 10 Rocky Skull"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 240 -40] [grid=C 4 C 2 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 200 -70] [grid=C 4 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-50 240 -10] [grid=C 3 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=50 240 -10] [grid=C 3 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 240 10] [grid=C 2 1 140 0]

--- a/parts/48492.dat
+++ b/parts/48492.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "Animal Horse Head Armour with Plates"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CLP [radius=4] [length=8] [center=true] [pos=0 -0.7 -51.8] [ori=0 1 0 -0.93969262 0 0.34202014 0.34202014 0 0.93969262]
+0 !LDCAD SNAP_CYL [group=horseCap] [gender=F] [caps=one] [secs=S 8 30] [pos=0 1 -4] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/569.dat
+++ b/parts/569.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Technic Gear  9 Large Tooth"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CLEAR [ID=studC]

--- a/parts/57536.dat
+++ b/parts/57536.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Constraction Head Connector Block Eye/Brain Stalk"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=axleHole] [gender=F] [caps=one] [secs=A 6 20] [slide=true] [pos=0 0 30] [ori=-1 0 0 0 0 1 0 1 0] [scale=YOnly]

--- a/parts/579p01.dat
+++ b/parts/579p01.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Electric Train Motor  4 x 12 x  4 - Cover with "4.5V" Pattern"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 72 100] [ori=-1 0 0 0 1 0 0 0 -1] [grid=C 4 C 2 20 20]

--- a/parts/580.dat
+++ b/parts/580.dat
@@ -1,0 +1,8 @@
+0 LDCad info for "~Electric Train Motor  4 x 12 x  4 Base"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 96 0] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 4 C 2 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-30 96 0] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 8 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=30 96 0] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 8 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 72 -100] [ori=-1 0 0 0 1 0 0 0 -1] [grid=C 4 C 2 20 20]

--- a/parts/59.dat
+++ b/parts/59.dat
@@ -1,5 +1,8 @@
 0 LDCad info for "Minifig Sword Greatsword"
 0 Author: Roland Melkert [roland]
 0 !LICENSE Free for non-commercial use.
+0 !HISTORY 2022-07-08 [MilanV] Fixed during update 22-03
 
 0 !LDCAD SNAP_CYL [gender=M] [caps=two] [secs=R 4 16] [slide=true] [pos=0 -8 0] [ori=-1 0 0 0 -1 0 0 0 1]
+0 !LDCAD SNAP_CYL [ID=studO] [gender=F] [caps=one] [secs=R 4 2] [pos=4 14 0] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [ID=studO] [gender=F] [caps=one] [secs=R 4 2] [pos=-4 14 0] [ori=0 -1 0 1 0 0 0 0 1]

--- a/parts/6023.dat
+++ b/parts/6023.dat
@@ -1,0 +1,12 @@
+0 LDCad info for "Minifig Jet-Pack with 2 Octagonal Nozzles (Needs Work)"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 26] [slide=true] [pos=26 -10.5 -27] [ori=1 0 0 0 0 1 0 -1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 26] [slide=true] [pos=-26 -10.5 -27] [ori=1 0 0 0 0 1 0 -1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 6   R 4 20] [slide=true] [pos=26 -10.5 25] [ori=-1 0 0 0 0 1 0 1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 6   R 4 26] [slide=true] [pos=-26 -10.5 25] [ori=-1 0 0 0 0 1 0 1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 6 10] [pos=0 9.5 25] [ori=1 0 0 0 0 -1 0 1 0] [grid=C 2 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 6 2] [slide=true]
+0 !LDCAD SNAP_CYL [gender=M] [caps=none] [secs=R 4 13] [slide=true] [pos=-22 22 -27.5] [ori=0.70710678 0 -0.70710678 -0.22436827 0.94832366 -0.22436827 0.67056609 0.31730466 0.67056609]
+0 !LDCAD SNAP_CYL [gender=M] [caps=none] [secs=R 4 13] [slide=true] [pos=22 22 -27.5] [ori=0.70710678 0 -0.70710678 -0.22436827 0.94832366 -0.22436827 0.67056609 0.31730466 0.67056609]

--- a/parts/6059.dat
+++ b/parts/6059.dat
@@ -1,8 +1,9 @@
 0 LDCad info for "Panel  3 x  3 x  6 Corner Round"
 0 Author: Roland Melkert [roland]
 0 !LICENSE Free for non-commercial use.
+0 !HISTORY 2022-07-08 [MilanV] Fixed during update 22-03
 
-0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=50 144 -10] [grid=1 2 0 20]
-0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=30 144 -30] [grid=1 2 0 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=50 144 -30] [grid=1 2 0 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=30 144 -50] [grid=1 2 0 20]
 0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=10 144 -50]
 0 !LDCAD MIRROR_INFO [counterPart=self] [oriCor=0 0 1 0 1 0 -1 0 0]

--- a/parts/61199c01.dat
+++ b/parts/61199c01.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Minifig Lightsaber Hilt Short Curved Light Bluish Grey - 1 Side On"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=none] [secs=R 4 5] [center=true] [slide=true] [pos=0 21 -0.5] [ori=-1 0 0 0 -0.9961947 0.08715574 0 0.08715574 0.9961947]
+0 !LDCAD SNAP_CYL [gender=M] [caps=none] [secs=R 4 5] [center=true] [slide=true] [pos=0 25.93922157 -1.23285912] [ori=-1 0 0 0 -0.99026807 0.1391731 0 0.1391731 0.99026807]
+0 !LDCAD SNAP_CYL [gender=M] [caps=none] [secs=R 4 5] [center=true] [slide=true] [pos=0 30.87507116 -1.92613235] [ori=-1 0 0 0 -0.98162719 0.19080899 0 0.19080899 0.98162719]

--- a/parts/6252.dat
+++ b/parts/6252.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Umbrella  8 x  8 with Curved Tabs"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 8] [pos=0 26 0]

--- a/parts/62743.dat
+++ b/parts/62743.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Wedge Plate  2 x 16 x  0.333 Triple with Axlehole"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 -120] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 14 C 2 20 20]

--- a/parts/65143.dat
+++ b/parts/65143.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Technic Shock Absorber 11L Body"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=-20 30 0] [ori=1 0 0 0 0 1 0 -1 0]

--- a/parts/6552.dat
+++ b/parts/6552.dat
@@ -1,0 +1,8 @@
+0 LDCad info for "Electric Technic Pole Reverser - Centre"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=axleHole] [gender=F] [caps=none] [secs=A 6 2] [slide=true] [pos=0 12 0] [scale=YOnly]
+0 !LDCAD SNAP_CYL [id=axleHole] [gender=F] [caps=none] [secs=A 6 2] [slide=true] [pos=0 -12 0] [ori=1 0 0 0 -1 0 0 0 -1] [scale=YOnly]
+0 !LDCAD SNAP_CYL [id=axleHole] [gender=F] [caps=none] [secs=A 6 2] [slide=true] [pos=12 0 0] [ori=0 1 0 1 0 0 0 0 -1] [scale=YOnly]
+0 !LDCAD SNAP_CYL [id=axleHole] [gender=F] [caps=none] [secs=A 6 2] [slide=true] [pos=-12 0 0] [ori=0 -1 0 1 0 0 0 0 1] [scale=YOnly]

--- a/parts/65611.dat
+++ b/parts/65611.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Minifig Hand Harpoon"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 2.5 13] [ori=1 0 0 0 0 1 0 -1 0]

--- a/parts/65753.dat
+++ b/parts/65753.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Minifig Skirt Straight Curved  0.55 Length"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-10 -3 0] [ori=1 0 0 0 -1 0 0 0 -1] [grid=2 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 11] [pos=-10 0 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 11] [pos=10 0 0]

--- a/parts/6582.dat
+++ b/parts/6582.dat
@@ -1,0 +1,11 @@
+0 LDCad info for "Wheel Rim 20 x 33 with  6 Pinholes"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=0 -20 -15] [ori=1 0 0 0 0 1 0 -1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=17.320508 -10 -15] [ori=1 0 0 0 0 1 0 1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=17.320508 10 -15] [ori=1 0 0 0 0 1 0 1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=-17.320508 -10 -15] [ori=1 0 0 0 0 1 0 1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=-17.320508 10 -15] [ori=1 0 0 0 0 1 0 1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=0 20 -15] [ori=1 0 0 0 0 1 0 1 0]
+0 !LDCAD SNAP_CYL [id=axleHole] [gender=F] [caps=none] [secs=A 6 19] [slide=true] [pos=0 0 -8] [ori=1 0 0 0 0 1 0 -1 0] [scale=YOnly]

--- a/parts/67139.dat
+++ b/parts/67139.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Technic Connector Block  3 x  5 x  1 with Cutout"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+1 16 0 0 0 1 0 0 0 1 0 0 0 -1 s\67139s01.dat
+0 !LDCAD SNAP_CYL [ID=connhol3] [gender=F] [caps=none] [secs=R 6 16   R 8 2] [center=true] [pos=-20 0 -21] [ori=1 0 0 0 0 -1 0 1 0]
+0 !LDCAD SNAP_CYL [ID=connhol3] [gender=F] [caps=none] [secs=R 6 16   R 8 2] [center=true] [pos=20 0 -21] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/73111.dat
+++ b/parts/73111.dat
@@ -1,0 +1,8 @@
+0 LDCad info for "Brick  3 x  3 x  2 Round with Recessed Centre"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 48 0] [grid=C 2 C 2 40 40]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 20] [pos=0 48 0] [grid=1 C 2 0 40]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 20] [pos=0 48 0] [ori=0 0 -1 0 1 0 1 0 0] [grid=1 C 2 0 40]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 48 0]

--- a/parts/73230.dat
+++ b/parts/73230.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Technic Brick  1 x  1 with Axlehole"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 4] [pos=0 24 0]

--- a/parts/735.dat
+++ b/parts/735.dat
@@ -1,5 +1,0 @@
-0 LDCad info for "Magnet Holder for Train Base  6 x 16 Type 1 with Magnet (Complete)"
-0 Author: Roland Melkert [roland]
-0 !LICENSE Free for non-commercial use.
-
-0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 6 12]

--- a/parts/75538.dat
+++ b/parts/75538.dat
@@ -1,0 +1,9 @@
+0 LDCad info for "Slope Concave  8 x  8 x  4 with  1 x  6 Plate"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [grid=C 6 C 2 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 -16 130] [grid=C 6 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 36] [pos=70 8 100] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 3 1 10 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 36] [pos=-70 8 100] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 3 1 10 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 36] [pos=0 -16 110] [ori=-1 0 0 0 1 0 0 0 -1] [grid=C 11 1 10 0]

--- a/parts/75539.dat
+++ b/parts/75539.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Slope  5 x  8 x  0.667 with  2 x  6 Plate"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 0] [grid=C 6 C 2 20 20]

--- a/parts/78666.dat
+++ b/parts/78666.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "Arch  1 x 2  x  1 Inverted"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=15 24 0] [grid=C 2 1 10 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 20] [pos=0 24 0]

--- a/parts/80031.dat
+++ b/parts/80031.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Plate 10 x 10 with Rounded End"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 20] [grid=C 10 C 8 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 -70] [grid=C 8 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 -90] [grid=C 6 1 20 0]

--- a/parts/84868.dat
+++ b/parts/84868.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Bar  2L T-shaped with Two Bar Holes and Bottom Tube"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=two] [secs=R 4 20] [slide=true] [pos=0 -28 0] [ori=1 0 0 0 -1 0 0 0 -1]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 10] [slide=true] [pos=-20 -38 0] [ori=0 -1 0 -1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 10] [slide=true] [pos=20 -38 0] [ori=0 1 0 1 0 0 0 0 -1]

--- a/parts/89519.dat
+++ b/parts/89519.dat
@@ -1,0 +1,9 @@
+0 LDCad info for "Bar Grille  9 x 13 with Studs and Tips"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 4 20] [slide=true] [pos=-80 0 70] [ori=1 0 0 0 0 1 0 -1 0] [grid=9 5 1 20 40 0]
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 4 8] [slide=true] [pos=-66 0 120] [ori=0 1 0 0 0 1 1 0 0] [grid=1 8 1 0 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 4 4] [slide=true] [pos=0 2 100]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 4] [slide=true] [pos=-60 8 -100] [grid=4 6 40 40]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 4 4] [slide=true] [pos=60 -8 -100] [ori=-1 0 0 0 -1 0 0 0 1] [grid=4 6 40 40]

--- a/parts/944.dat
+++ b/parts/944.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Axle Steel  6 x 96 LDU"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=none] [secs=R 3 96] [slide=true] [pos=-48 0 0] [ori=0 -1 0 1 0 0 0 0 1]

--- a/parts/94722.dat
+++ b/parts/94722.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Figure Friends Accessories Award Ribbon with Number 2"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 2 6] [slide=true] [ori=-1 0 0 0 0 1 0 1 0]

--- a/parts/98222.dat
+++ b/parts/98222.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Duplo Plate  4 x  4 Round with Snapping Ridges"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 12 20] [pos=0 24 0] [grid=C 4 C 4 40 40]

--- a/parts/98302.dat
+++ b/parts/98302.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Plate  1 x  2 with Jet Engine with Axle Hole and Slot"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 0] [grid=C 2 1 20 0]

--- a/parts/98313.dat
+++ b/parts/98313.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "Minifig Mechanical Arm with Clip and Rod Hole with Thick Forearm"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CLP [radius=4] [length=8] [center=true] [ori=1 0 0 0 0 1 0 -1 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 4 10] [slide=true] [pos=38 17.5 0] [ori=0 1 0 1 0 0 0 0 -1]
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 4 14] [slide=true] [pos=23.5 17.5 -7] [ori=0 0 -1 1 0 0 0 -1 0]

--- a/parts/s/23323s01.dat
+++ b/parts/s/23323s01.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "~Electric Motor Unit  6 x 18 x  4 Top - Left/Right"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=170 -54 -20] [ori=0 -1 0 0 0 -1 1 0 0]
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=170 -54 20] [ori=0 -1 0 0 0 -1 1 0 0]
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=120 -94 0] [grid=2 1 20 0]

--- a/parts/s/23324s01.dat
+++ b/parts/s/23324s01.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "~Electric Motor Unit  6 x 18 x  4 Bottom - Front/Back"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_INCL [ref=connhole.dat] [pos=130 -14 -50] [ori=1 0 0 0 0 1 0 -1 0] [grid=C 4 1 20 0]
+0 !LDCAD SNAP_INCL [ref=connhole.dat] [pos=160 -54 -50] [ori=1 0 0 0 0 1 0 -1 0]

--- a/parts/s/23324s02.dat
+++ b/parts/s/23324s02.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "~Electric Motor Unit  6 x 18 x  4 Bottom - End"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_INCL [ref=connhole.dat] [pos=170 -14 0] [ori=0 1 0 0 0 1 1 0 0] [grid=C 3 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 4] [pos=170 0 0] [ori=0 0 1 0 1 0 -1 0 0] [grid=C 4 1 20 0]

--- a/parts/s/2528as01.dat
+++ b/parts/s/2528as01.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "~Minifig Hat Bicorne without Patternable Surfaces"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 2 8] [pos=15.2 -12.5 0] [ori=-1 0 0 0 -1 0 0 0 1]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 8]

--- a/parts/s/32064s01.dat
+++ b/parts/s/32064s01.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Technic Brick  1 x  2 with Axlehole"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-10 24 0] [grid=2 1 20 0]

--- a/parts/s/4492s02.dat
+++ b/parts/s/4492s02.dat
@@ -2,4 +2,7 @@
 0 Author: Roland Melkert [roland]
 0 !LICENSE Free for non-commercial use.
 
+0 !HISTORY 2022-07-10 [MilanV] Snap info for horse cap added
+
 0 !LDCAD SNAP_GEN [group=horse] [gender=F] [bounding=cyl 16 10] [placement=free] [ori=0 1 0 0 0 -1 -1 0 0]
+0 !LDCAD SNAP_CYL [group=horseCap] [gender=M] [caps=one] [secs=S 8 30] [pos=0 -56 -4] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/s/49656s02.dat
+++ b/parts/s/49656s02.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Rock  1 x  1 Geode Matrix"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4]

--- a/parts/s/6180s01.dat
+++ b/parts/s/6180s01.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Tile  4 x  6 with Studs on Edges without Top Face"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 0] [grid=C 6 C 4 20 20]

--- a/parts/s/64867s01.dat
+++ b/parts/s/64867s01.dat
@@ -1,0 +1,9 @@
+0 LDCad info for "~Wedge  4 x  4 Fractured Polygon Top - Base"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 24 -50] [grid=C 2 C 2 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 8 0] [grid=C 2 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=30 24 -20] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 3 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-30 24 -20] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 3 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 16 -20] [grid=C 2 1 20 0]

--- a/parts/s/66787s01.dat
+++ b/parts/s/66787s01.dat
@@ -1,0 +1,7 @@
+0 LDCad info for "~Cylinder Warp Pipe  6 x  6 x  3.333 Quarter"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 24] [pos=50 0 -10] [ori=0 0 -1 0 1 0 1 0 0] [grid=2 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=50 0 30]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=30 0 50]

--- a/parts/s/68881s02.dat
+++ b/parts/s/68881s02.dat
@@ -1,0 +1,13 @@
+0 LDCad info for "~Brick 10 x  5 x  2.667 Semi Circle with Curved Top, Main Colour - without Patternable Surface"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=stud3] [gender=M] [caps=one] [secs=R 4 4] [pos=-20 -28 10] [ori=-1 0 0 0 -1 0 0 0 1] [scale=YOnly]
+0 !LDCAD SNAP_CYL [id=stud3] [gender=M] [caps=one] [secs=R 4 4] [pos=20 -28 10] [ori=-1 0 0 0 -1 0 0 0 1] [scale=YOnly]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 4] [pos=0 -24 10] [grid=C 4 1 20 0]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 4] [pos=50 -16 10]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 4] [pos=-50 -16 10]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 18] [pos=-70 0 10]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=S 6 18] [pos=70 0 10]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=-90 0 10]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=90 0 10]

--- a/parts/s/777s02.dat
+++ b/parts/s/777s02.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Flag on Flagpole Type 2 without Faces"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 6 20] [pos=0 24 0]

--- a/parts/s/786s01.dat
+++ b/parts/s/786s01.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Flag on Flagpole Type 4 without Faces"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 6 20] [pos=0 24 0]

--- a/parts/s/92084s01.dat
+++ b/parts/s/92084s01.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Animal Owl with Angular Feathers - Body"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 5]

--- a/parts/s/98088s01.dat
+++ b/parts/s/98088s01.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "~Animal Wing Left Pteranodon Front"
+0 Author: Milan Vančura [Milan Vančura]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=two] [secs=R 4 8] [slide=true] [pos=0 0 -6] [ori=0 0 -1 -1 0 0 0 1 0]
+0 !LDCAD SNAP_CYL [gender=M] [caps=two] [secs=R 4 8] [slide=true] [pos=0 0 14] [ori=0 0 -1 -1 0 0 0 1 0]

--- a/parts/s/u454s01.dat
+++ b/parts/s/u454s01.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Signpost Slanted Cantilever without Decorated Faces"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [grid=C 2 C 2 20 20]

--- a/parts/t1071.dat
+++ b/parts/t1071.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "| BBB Train Wheel Medium Flanged Driver 24.0 mm"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=0 -15 -10] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/t1072.dat
+++ b/parts/t1072.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "| BBB Train Wheel Flanged Driver 30.4 mm"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=0 -20 -12] [ori=1 0 0 0 0 -1 0 1 0]

--- a/parts/u9068.dat
+++ b/parts/u9068.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Rack Winder  2 x  4 x  2 Axle"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [id=axle] [gender=M] [caps=none] [secs=A 6 20] [slide=true] [pos=-60 0 0] [ori=0 -1 0 1 0 0 0 0 1] [scale=YOnly]

--- a/parts/u9235.dat
+++ b/parts/u9235.dat
@@ -1,0 +1,6 @@
+0 LDCad info for "~Motor Wind-Up  4 x 10 x  3 Bottom (Needs Work)"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 72 20] [ori=0 0 -1 0 1 0 1 0 0] [grid=C 6 C 4 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 48 -70] [grid=C 4 C 3 20 20]

--- a/parts/u9236.dat
+++ b/parts/u9236.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Motor Windup  4 x 10 x  3 Top (Needs Work)"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 24] [pos=-30 48 90] [grid=4 1 20 0]

--- a/parts/u9255.dat
+++ b/parts/u9255.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Magnet Holder for Train Base  6 x 16 Type 1"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=M] [caps=one] [secs=R 6 12]

--- a/parts/u9483.dat
+++ b/parts/u9483.dat
@@ -1,0 +1,8 @@
+0 LDCad info for "~Electric Motor  4 x 12 x  3.333 Type 3 Base (Needs Work)"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 56 100] [grid=C 4 C 2 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 56 -100] [grid=C 4 C 2 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 80 40] [grid=C 4 C 4 20 20]
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 80 -60] [grid=C 4 C 2 20 20]

--- a/parts/u9550.dat
+++ b/parts/u9550.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "~Train Wheel Spoked with Cylindrical Rim with 6 LDU Axle Hole"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=none] [secs=R 3 17] [slide=true] [pos=0 0 -8] [ori=1 0 0 0 0 1 0 -1 0]

--- a/parts/u9551.dat
+++ b/parts/u9551.dat
@@ -1,0 +1,9 @@
+0 LDCad info for "~Electric Record and Play Brick 16 x 10 x  4 Bottom (Needs Work)"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 6 4] [pos=0 6 -80] [grid=C 8 C 4 20 20]
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=70 -26 -20] [ori=0 -1 0 1 0 0 0 0 1] [grid=1 4 0 40]
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=-70 -26 100] [ori=0 1 0 1 0 0 0 0 -1] [grid=1 4 0 40]
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=-20 -26 -150] [ori=0 0 1 1 0 0 0 1 0] [grid=1 2 0 40]
+0 !LDCAD SNAP_CYL [id=connhole] [gender=F] [caps=none] [secs=R 8 2   R 6 16   R 8 2] [center=true] [slide=true] [pos=-60 -26 -130] [ori=0 0 1 1 0 0 0 1 0] [grid=1 2 0 120]

--- a/parts/u977.dat
+++ b/parts/u977.dat
@@ -1,0 +1,5 @@
+0 LDCad info for "Duplo Arch  2 x  3 x  3"
+0 Author: Milan Vančura [MilanV]
+0 !LICENSE Licenced under CC BY 4.0 : see CAreadme.txt
+
+0 !LDCAD SNAP_CYL [gender=F] [caps=one] [secs=R 12 44] [pos=0 144 -20] [grid=1 2 0 40]


### PR DESCRIPTION
Commit messages contain detailed information about each part check: whether it is OK (or bad: marked as '✗') and details like which subpart contains the real shadow info or if another parts were also modified to make such part working etc.

According to what I posted to ldraw forum the set of 22-03 shadow info's I fixed dinosaur parts: snap object need group attribute instead of ID one to match each other, according to Roland's documentation.